### PR TITLE
Use different syntax for environment variables

### DIFF
--- a/.github/workflows/ci_except_main.yml
+++ b/.github/workflows/ci_except_main.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          php-version: $php_version
+          php-version: ${{ env.php_version }}
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict

--- a/.github/workflows/deploy_dev.yml
+++ b/.github/workflows/deploy_dev.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          php-version: $php_version
+          php-version: ${{ env.php_version }}
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict

--- a/.github/workflows/deploy_live.yml
+++ b/.github/workflows/deploy_live.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          php-version: $php_version
+          php-version: ${{ env.php_version }}
 
       - name: Get Composer cache directory
         id: composer-cache-dir

--- a/.github/workflows/deploy_multidev.yml
+++ b/.github/workflows/deploy_multidev.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          php-version: $php_version
+          php-version: ${{ env.php_version }}
 
       - name: Validate composer.json and composer.lock
         run: composer validate --strict

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          php-version: $php_version
+          php-version: ${{ env.php_version }}
 
       - name: Get Composer cache directory
         id: composer-cache-dir


### PR DESCRIPTION
Ensure that the correct version number is retrieved and used when
configuring PHP.

For my own site, I was using the same syntax but today, builds were
failing as Actions started using PHP 8 due to an error when setting up
PHP in it's step.

After switching to this syntax, the builds are now running correctly
using PHP 7.4.